### PR TITLE
Deprecate No Translate feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.2
+- Deprecate No Translate feature
+
 # 2.1.1
 20.02.2023
 - Enhancement: makes missing tag spaces disabled by default

--- a/src/js/wpgpt-consistency.js
+++ b/src/js/wpgpt-consistency.js
@@ -43,7 +43,9 @@ function consistency_tools() {
 		wpgpt_anonymous();
 		wpgpt_localdate();
 		wpgpt_observer();
-		wpgpt_notranslate();
+		if ( 'enabled' === _wpgpt_settings.using_legacy_notranslate ) {
+			wpgpt_notranslate();
+		}
 	}
 	wpgpt_gt();
 	wpgpt_events();

--- a/src/js/wpgpt-settings.js
+++ b/src/js/wpgpt-settings.js
@@ -171,6 +171,12 @@ const wpgpt_settings = {
 		'setting_type':   2,
 		'parent_setting': 'others',
 	},
+	'using_legacy_notranslate': {
+		'desc':           '(Deprecated) Non Translatable feature',
+		'state':          'disabled',
+		'setting_type':   2,
+		'parent_setting': 'others',
+	},
 };
 const settings_li = document.createElement( 'li' );
 settings_li.classList.add( 'menu-item', 'wpgpt_settings_menu' );


### PR DESCRIPTION
Marked the No Translate feature as deprecated by introducing a new 'using_legacy_notranslate' setting and updating logic to only enable it if explicitly set. Updated the changelog to reflect this deprecation.