### PR TITLE
Add event.preventDefault() for filter click events

### DIFF
--- a/src/js/wpgpt-checks.js
+++ b/src/js/wpgpt-checks.js
@@ -815,11 +815,17 @@ function wpgpt_filters() {
 	}
 
 	paging && document.querySelector( '.wpgpt-filter-warnings' ).addEventListener( 'click', () => {
+		if (event) {
+        event.preventDefault();
+        }
 		document.querySelectorAll( 'tr.preview' ).forEach( ( el ) => { el.style.display = 'none'; } );
 		document.querySelectorAll( 'tr.preview.wpgpt-has-warning' ).forEach( ( el ) => { el.style.display = 'table-row'; } );
 	} );
 
 	paging && document.querySelector( '.wpgpt-filter-notices' ).addEventListener( 'click', () => {
+		if (event) {
+        event.preventDefault();
+        }
 		document.querySelectorAll( 'tr.preview' ).forEach( ( el ) => { el.style.display = 'none'; } );
 		document.querySelectorAll( 'tr.preview.wpgpt-has-notice' ).forEach( ( el ) => { el.style.display = 'table-row'; } );
 	} );


### PR DESCRIPTION
Prevent default action for filter warning and notice clicks. This prevents the page to reload after clicking on the warning box